### PR TITLE
Avoid using complex number literal extension.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,19 +26,33 @@ jobs:
 
   gcc:
     runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        cxx: [gcc, clang]
-    name: ${{ matrix.cxx }}
     env:
-      CXX: ${{ matrix.cxx }}
+      CXX: g++-12
+      CC: gcc-12
     steps:
     - uses: actions/checkout@v4
     - name: CMake
       run: |
         sudo apt-get update
-        sudo apt-get install libhdf5-dev g++-12
-        CXX=g++-12 cmake -B build
+        sudo apt-get install libhdf5-dev $CXX $CC
+        cmake -B build
+    - name: Build
+      run: VERBOSE=true make -C build -j `nproc`
+    - name: Test
+      run: ctest --test-dir ./build/test/bash
+
+  clang:
+    runs-on: 'ubuntu-latest'
+    env:
+      CXX: clang++
+      CC: clang
+    steps:
+    - uses: actions/checkout@v4
+    - name: CMake
+      run: |
+        sudo apt-get update
+        sudo apt-get install libhdf5-dev clang
+        cmake -B build
     - name: Build
       run: VERBOSE=true make -C build -j `nproc`
     - name: Test

--- a/include/binsparse/detail/declamp_values.h
+++ b/include/binsparse/detail/declamp_values.h
@@ -42,7 +42,12 @@ static inline void bsp_matrix_declamp_values(bsp_matrix_t matrix) {
       real_value = bsp_suitesparse_declamp_impl_(real_value);
       imaginary_value = bsp_suitesparse_declamp_impl_(imaginary_value);
 
-      values[i] = real_value + 1j * imaginary_value;
+      double _Complex complex_value;
+
+      ((double*) &complex_value)[0] = real_value;
+      ((double*) &complex_value)[1] = imaginary_value;
+
+      values[i] = complex_value;
     }
   }
 }

--- a/include/binsparse/matrix_market/matrix_market_read.h
+++ b/include/binsparse/matrix_market/matrix_market_read.h
@@ -89,7 +89,10 @@ static inline bsp_matrix_t bsp_mmread_explicit_array(const char* file_path,
       double real_value, imaginary_value;
       sscanf(buf, "%lf %lf", &real_value, &imaginary_value);
 
-      double _Complex value = real_value + 1j * imaginary_value;
+      double _Complex value;
+
+      ((double*) &value)[0] = real_value;
+      ((double*) &value)[1] = imaginary_value;
 
       size_t i = count % matrix.ncols;
       size_t j = count / matrix.ncols;
@@ -203,12 +206,15 @@ bsp_mmread_explicit_coordinate(const char* file_path, bsp_type_t value_type,
       bsp_array_write(matrix.indices_1, count, j);
     } else if (mm_type == BSP_MM_COMPLEX) {
       unsigned long long i, j;
-      double real_value, complex_value;
-      sscanf(buf, "%llu %llu %lf %lf", &i, &j, &real_value, &complex_value);
+      double real_value, imaginary_value;
+      sscanf(buf, "%llu %llu %lf %lf", &i, &j, &real_value, &imaginary_value);
       i--;
       j--;
 
-      double _Complex value = real_value + 1j * complex_value;
+      double _Complex value;
+
+      ((double*) &value)[0] = real_value;
+      ((double*) &value)[1] = imaginary_value;
 
       bsp_array_write(matrix.values, count, value);
       bsp_array_write(matrix.indices_0, count, i);

--- a/test/bash/CMakeLists.txt
+++ b/test/bash/CMakeLists.txt
@@ -22,6 +22,9 @@ download_data(https://suitesparse-collection-website.herokuapp.com/MM/Belcastro/
 download_data(https://suitesparse-collection-website.herokuapp.com/MM/Pajek/IMDB.tar.gz
               IMDB.tar.gz)
 
+download_data(https://suitesparse-collection-website.herokuapp.com/MM/Bai/dwg961a.tar.gz
+              dwg961a.tar.gz)
+
 find_program(BASH_PROGRAM bash)
 
 enable_testing()
@@ -31,9 +34,11 @@ if(BASH_PROGRAM)
      add_test(NAME integration.1138_bus COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${CMAKE_BINARY_DIR}/data/1138_bus.tar.gz)
      add_test(NAME integration.mouse_gene COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${CMAKE_BINARY_DIR}/data/mouse_gene.tar.gz)
      add_test(NAME integration.IMDB COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${CMAKE_BINARY_DIR}/data/IMDB.tar.gz)
+     add_test(NAME integration.dwg961a COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${CMAKE_BINARY_DIR}/data/dwg961a.tar.gz)
 
      add_test(NAME integration.cpp.chesapeake COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test-cpp.sh ${CMAKE_BINARY_DIR}/data/chesapeake.tar.gz)
      add_test(NAME integration.cpp.1138_bus COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test-cpp.sh ${CMAKE_BINARY_DIR}/data/1138_bus.tar.gz)
      add_test(NAME integration.cpp.mouse_gene COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test-cpp.sh ${CMAKE_BINARY_DIR}/data/mouse_gene.tar.gz)
      add_test(NAME integration.cpp.IMDB COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test-cpp.sh ${CMAKE_BINARY_DIR}/data/IMDB.tar.gz)
+     add_test(NAME integration.cpp.dwg961a COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test-cpp.sh ${CMAKE_BINARY_DIR}/data/dwg961a.tar.gz)
 endif()


### PR DESCRIPTION
Previously, I used the complex number literal compiler extension to build complex numbers as well as extract their real and imaginary parts.  (e.g. `double _Complex = 2 + 1j` to build the number `2 + i`.)

This was nice because it avoided using `<complex.h>` as well as C++'s `<complex>`.  However, not all compilers support these extensions by default.  (You need to use `-std=gnu++20` instead of `-std=c++20`.)

This PR modifies the repo to no longer use these literals, instead relying on the C specification's guaranteed memory layout for complex numbers.